### PR TITLE
Use new Rockset Python client, specify supported SQLAlchemy versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,4 +11,8 @@ setup(
         ]
     },
     extras_require=dict(sqlalchemy=["sqlalchemy>=1.0,<1.4", "geojson>=2.5.0"]),
+    install_requires=[
+        "rockset>=1.0.0",
+        "sqlalchemy>=1.4.0,<2.0.0"
+    ],
 )

--- a/src/rockset_sqlalchemy/client/connection.py
+++ b/src/rockset_sqlalchemy/client/connection.py
@@ -1,5 +1,5 @@
 import rockset
-from rockset import Client, Q
+from rockset import RocksetClient, Regions
 
 from .cursor import Cursor
 from .exceptions import Error, ProgrammingError
@@ -8,14 +8,17 @@ from .exceptions import Error, ProgrammingError
 class Connection(object):
     def __init__(self, api_server, api_key, debug_sql=False):
         self._closed = False
-        self._client = Client(api_server=api_server, api_key=api_key)
+        self._client = RocksetClient(
+            host=api_server or Regions.use1a1, 
+            api_key=api_key
+        )
         self.debug_sql = debug_sql
-
         # Used for testing connectivity to Rockset.
         try:
-            cursor = self._client.sql(Q("SELECT 1"))
-            cursor.results()
-        except rockset.exception.Error as e:
+            self._client.Queries.query(
+                sql={ "query": "SELECT 1" }
+            ).results
+        except rockset.exceptions.RocksetException as e:
             raise Error.map_rockset_exception(e)
 
     def cursor(self):

--- a/src/rockset_sqlalchemy/client/cursor.py
+++ b/src/rockset_sqlalchemy/client/cursor.py
@@ -79,19 +79,19 @@ class Cursor(object):
         return tuple(result)
 
     def _response_to_column_fields(self, column_fields):
+        # find the data type of each column by looking at
+        # the result set.
         if column_fields:
             columns = [cf["name"] for cf in column_fields]
 
         schema = rockset.Document()
-        for r in self._get_docs(self._response):
-            schema.update(r)
+        if self._response.results and len(self._response.results) > 0:
+            # we only look at the first document because 
+            # is sqlalchemy is typically used for relational
+            # tables with no sparse fields
+            schema.update(self._response.results[0])
 
         return schema.fields(columns=columns)
-
-    def _get_docs(self, response):
-        if not response.results:
-            return []
-        return [rockset.Document(row) for row in response.results]
 
     def fetchall(self):
         docs = []

--- a/src/rockset_sqlalchemy/client/cursor.py
+++ b/src/rockset_sqlalchemy/client/cursor.py
@@ -1,7 +1,7 @@
+import sys
 import json
 
 import rockset
-from rockset.query import QueryStringSQLText
 
 from .exceptions import Error, ProgrammingError
 
@@ -10,13 +10,13 @@ class Cursor(object):
     def __init__(self, connection):
         self._connection = connection
         self._closed = False
-        self._cursor = None
         self.arraysize = 1
+        self._response = None
+        self._response_iter = None
 
     def execute(self, sql, parameters=None):
         self.__check_cursor_opened()
 
-        # Serialize all list parameters to strings.
         new_params = {}
         for k, v in parameters.items():
             if isinstance(v, list):
@@ -24,14 +24,13 @@ class Cursor(object):
             else:
                 new_params[k] = v
         parameters = new_params
-
+        
         if self._connection.debug_sql:
             print("+++++++++++++++++++++++++++++")
             print(f"Query:\n{sql}")
-            print(f"\nParameters:\n{new_params}")
+            print(f"\nParameters:\n{parameters}")
             print("+++++++++++++++++++++++++++++")
 
-        q = QueryStringSQLText(sql)
         if parameters:
             if not isinstance(parameters, dict):
                 raise ProgrammingError(
@@ -39,13 +38,13 @@ class Cursor(object):
                         type(parameters)
                     )
                 )
-            q.P.update(parameters)
 
-        try:
-            self._cursor = self._connection._client.sql(q=q)
-            self._cursor_iter = iter(self._cursor.results())
-        except rockset.exception.Error as e:
-            raise Error.map_rockset_exception(e)
+        self._response = self._connection._client.sql(
+            query=sql,
+            params=parameters
+        )
+        
+        self._response_iter = iter(self._response.results)
 
     def executemany(self, sql, all_parameters):
         for parameters in all_parameters:
@@ -55,17 +54,18 @@ class Cursor(object):
         self.__check_cursor_opened()
 
         try:
-            next_doc = next(self._cursor_iter)
+            next_doc = next(self._response_iter)
         except StopIteration:
             return None
-        except rockset.exception.Error as e:
+        except rockset.exceptions.RocksetException as e:
             raise Error.map_rockset_exception(e)
 
         if not next_doc:
             return None
 
         result = []
-        for field in self._cursor.fields():
+        
+        for field in self._response_to_column_fields(self._response.column_fields):           
             name = field["name"]
             if name in next_doc:
                 result.append(next_doc[name])
@@ -73,6 +73,21 @@ class Cursor(object):
                 result.append(None)
 
         return tuple(result)
+
+    def _response_to_column_fields(self, column_fields):
+        if column_fields:
+            columns = [cf["name"] for cf in column_fields]
+
+        schema = rockset.Document()
+        for r in self._get_docs(self._response):
+            schema.update(r)
+
+        return schema.fields(columns=columns)
+
+    def _get_docs(self, response):
+        if not response.results:
+            return []
+        return [rockset.Document(row) for row in response.results]
 
     def fetchall(self):
         docs = []
@@ -96,11 +111,11 @@ class Cursor(object):
 
     @property
     def description(self):
-        if self._cursor is None:
+        if self._response is None:
             return None
 
         desc = []
-        for field in self._cursor.fields():
+        for field in self._response_to_column_fields(self._response.column_fields):
             name, type_ = field["name"], field["type"]
             null_ok = name != "_id" and "__id" not in name
 
@@ -127,7 +142,7 @@ class Cursor(object):
     @property
     def rowcount(self):
         self.__check_cursor_opened()
-        return self._cursor.rowcount()
+        return len(self._response.results)
 
     def __check_cursor_opened(self):
         if self._connection._closed:

--- a/src/rockset_sqlalchemy/client/exceptions.py
+++ b/src/rockset_sqlalchemy/client/exceptions.py
@@ -1,36 +1,37 @@
 import rockset
+from json import loads
 
 class Error(rockset.exceptions.RocksetException):
     @classmethod
-    def map_rockset_exception(cls, exc, **kwargs):
-        kwargs["message"] = exc.message
-        kwargs["code"] = hasattr(exc, "code") and exc.code or None
-        kwargs["type"] = hasattr(exc, "type") and exc.type or None  
+    def map_rockset_exception(cls, exc):
+        err_body = loads(exc.body)
+        args = [
+            err_body["message"],
+            exc.status,
+            err_body["type"]
+        ]
         exc_type = type(exc)
-        
         if (
             exc_type == rockset.exceptions.ApiTypeError or
             exc_type == rockset.exceptions.ApiValueError or
             exc_type == rockset.exceptions.ApiAttributeError or
             exc_type == rockset.exceptions.ApiKeyError or 
-            exc_type == rockset.exceptions.NotFoundException
+            exc_type == rockset.exceptions.NotFoundException or
+            exc_type == rockset.exceptions.InputException or  
+            exc_type == rockset.exceptions.InitializationException or
+            exc_type == rockset.exceptions.BadRequestException
+
         ):
-            ret = ProgrammingError(**kwargs)
+            ret = ProgrammingError(*args)
         elif (
             exc_type == rockset.exceptions.UnauthorizedException or 
             exc_type == rockset.exceptions.ForbiddenException
         ):
-            ret = OperationalError(**kwargs)
-        elif (
-            exc_type == rockset.exceptions.InputException or  
-            exc_type == rockset.exceptions.InitializationException or
-            exc_type == rockset.exceptions.BadRequestException
-        ):
-            ret = InputError(**kwargs)
+            ret = OperationalError(*args)
         elif exc_type == ServiceException:
-            ret = InternalError(**kwargs)
+            ret = InternalError(*args)
         else:
-            ret = cls(**kwargs)
+            ret = cls(*args)
         return ret
 
 

--- a/src/rockset_sqlalchemy/client/exceptions.py
+++ b/src/rockset_sqlalchemy/client/exceptions.py
@@ -1,28 +1,34 @@
 import rockset
 
-
-class Error(rockset.exception.Error):
+class Error(rockset.exceptions.RocksetException):
     @classmethod
     def map_rockset_exception(cls, exc, **kwargs):
         kwargs["message"] = exc.message
         kwargs["code"] = hasattr(exc, "code") and exc.code or None
-        kwargs["type"] = hasattr(exc, "type") and exc.type or None
-        if type(exc) == rockset.exception.ServerError:
-            ret = InternalError(**kwargs)
-        elif type(exc) == rockset.exception.NotYetImplemented:
-            ret = NotSupportedError(**kwargs)
-        elif type(exc) == rockset.exception.AuthError:
-            ret = OperationalError(**kwargs)
-        elif type(exc) == rockset.exception.LimitReached:
-            ret = OperationalError(**kwargs)
-        elif type(exc) == rockset.exception.ResourceSuspendedError:
-            ret = OperationalError(**kwargs)
-        elif type(exc) == rockset.exception.RequestTimeout:
-            ret = OperationalError(**kwargs)
-        elif type(exc) == rockset.exception.TransientServerError:
-            ret = OperationalError(**kwargs)
-        elif type(exc) == rockset.exception.InputError:
+        kwargs["type"] = hasattr(exc, "type") and exc.type or None  
+        exc_type = type(exc)
+        
+        if (
+            exc_type == rockset.exceptions.ApiTypeError or
+            exc_type == rockset.exceptions.ApiValueError or
+            exc_type == rockset.exceptions.ApiAttributeError or
+            exc_type == rockset.exceptions.ApiKeyError or 
+            exc_type == rockset.exceptions.NotFoundException
+        ):
             ret = ProgrammingError(**kwargs)
+        elif (
+            exc_type == rockset.exceptions.UnauthorizedException or 
+            exc_type == rockset.exceptions.ForbiddenException
+        ):
+            ret = OperationalError(**kwargs)
+        elif (
+            exc_type == rockset.exceptions.InputException or  
+            exc_type == rockset.exceptions.InitializationException or
+            exc_type == rockset.exceptions.BadRequestException
+        ):
+            ret = InputError(**kwargs)
+        elif exc_type == ServiceException:
+            ret = InternalError(**kwargs)
         else:
             ret = cls(**kwargs)
         return ret

--- a/src/rockset_sqlalchemy/client/sqlalchemy/dialect.py
+++ b/src/rockset_sqlalchemy/client/sqlalchemy/dialect.py
@@ -1,7 +1,5 @@
 import json
 
-import rockset
-from rockset import Client
 from sqlalchemy import exc, types, util
 from sqlalchemy.engine import default, reflection
 from sqlalchemy.sql import compiler


### PR DESCRIPTION
Before this change:
* The version of the SQLAlchemy library was not specified in `setup.py`, so running rockset_sqlalchemy fails because it only worked for `"sqlalchemy>=1.4.0,<2.0.0"` (not the latest version).
* The version of the rockset library was not specified in `setup.py`, so running rockset_sqlalchemy fails because it only worked for `rockset<1.0.0` (outdated).

After this change:
* The library now uses the latest Python client ([2.0.0](https://pypi.org/project/rockset/2.0.0/))
* The supported versions for rockset and SQLAlchemy libraries are defined in `setup.py`