### PR TITLE
Fix v2 support

### DIFF
--- a/example.py
+++ b/example.py
@@ -19,7 +19,7 @@ if "ROCKSET_API_KEY" not in os.environ:
     sys.exit(1)
 
 engine = create_engine(
-    "rockset_sqlalchemy://",
+    "rockset://",
     connect_args={
         "host": os.environ["ROCKSET_API_SERVER"],
         "username": os.environ["ROCKSET_API_KEY"],

--- a/example.py
+++ b/example.py
@@ -21,8 +21,8 @@ if "ROCKSET_API_KEY" not in os.environ:
 engine = create_engine(
     "rockset_sqlalchemy://",
     connect_args={
-        "api_server": os.environ["ROCKSET_API_SERVER"],
-        "api_key": os.environ["ROCKSET_API_KEY"],
+        "host": os.environ["ROCKSET_API_SERVER"],
+        "username": os.environ["ROCKSET_API_KEY"],
     },
 )
 

--- a/example.py
+++ b/example.py
@@ -21,8 +21,8 @@ if "ROCKSET_API_KEY" not in os.environ:
 engine = create_engine(
     "rockset://",
     connect_args={
-        "host": os.environ["ROCKSET_API_SERVER"],
-        "username": os.environ["ROCKSET_API_KEY"],
+        "api_server": os.environ["ROCKSET_API_SERVER"],
+        "api_key": os.environ["ROCKSET_API_KEY"],
     },
 )
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(
     packages=find_packages("src"),
     entry_points={
         "sqlalchemy.dialects": [
-            "rockset_sqlalchemy = rockset_sqlalchemy.client.sqlalchemy:RocksetDialect"
+            "rockset_sqlalchemy = rockset_sqlalchemy.client.sqlalchemy:RocksetDialect",
+            "rockset = rockset_sqlalchemy.client.sqlalchemy:RocksetDialect"
         ]
     },
     extras_require=dict(sqlalchemy=["sqlalchemy>=1.0,<1.4", "geojson>=2.5.0"]),

--- a/src/rockset_sqlalchemy/client/__init__.py
+++ b/src/rockset_sqlalchemy/client/__init__.py
@@ -1,7 +1,7 @@
 from .connection import Connection as connect
 from .exceptions import Error
 
-__all__ = [connect, Error]
+__all__ = ["connect", "Error"]
 
 apilevel = "2.0"
 

--- a/src/rockset_sqlalchemy/client/connection.py
+++ b/src/rockset_sqlalchemy/client/connection.py
@@ -4,13 +4,12 @@ from rockset import RocksetClient, Regions
 from .cursor import Cursor
 from .exceptions import Error, ProgrammingError
 
-
 class Connection(object):
-    def __init__(self, host, username, debug_sql=False):
+    def __init__(self, api_server, api_key, debug_sql=False):
         self._closed = False
         self._client = RocksetClient(
-            host=host or Regions.use1a1, 
-            api_key=username
+            host=api_server, 
+            api_key=api_key
         )
         self.debug_sql = debug_sql
         # Used for testing connectivity to Rockset.

--- a/src/rockset_sqlalchemy/client/connection.py
+++ b/src/rockset_sqlalchemy/client/connection.py
@@ -6,11 +6,11 @@ from .exceptions import Error, ProgrammingError
 
 
 class Connection(object):
-    def __init__(self, api_server, api_key, debug_sql=False):
+    def __init__(self, host, username, debug_sql=False):
         self._closed = False
         self._client = RocksetClient(
-            host=api_server or Regions.use1a1, 
-            api_key=api_key
+            host=host or Regions.use1a1, 
+            api_key=username
         )
         self.debug_sql = debug_sql
         # Used for testing connectivity to Rockset.
@@ -27,7 +27,7 @@ class Connection(object):
         raise ProgrammingError("Connection closed")
 
     def close(self):
-        self._client.close()
+        self._client = None
         self._closed = True
 
     def rollback(self):

--- a/src/rockset_sqlalchemy/client/cursor.py
+++ b/src/rockset_sqlalchemy/client/cursor.py
@@ -16,7 +16,7 @@ class Cursor(object):
         self._response_iter = None
 
     @staticmethod
-    def _convert_to_rockset_type(v):
+    def __convert_to_rockset_type(v):
         if isinstance(v, bool):
             return "bool"
         elif isinstance(v, int):
@@ -32,6 +32,8 @@ class Cursor(object):
             return "date"
         elif isinstance(v, dict) or isinstance(v, list):
             return "object"
+        elif v is None:
+            return "null"
         raise TypeError(
             "Parameter value of type {} is not supported by Rockset".format(type(v))
         )
@@ -144,7 +146,7 @@ class Cursor(object):
 
         desc = []
         for field_name, field_value in self._response.results[0].items():
-            name, type_ = field_name, Cursor._convert_to_rockset_type(field_value)
+            name, type_ = field_name, Cursor.__convert_to_rockset_type(field_value)
             null_ok = name != "_id" and "__id" not in name
 
             # name, type_code, display_size, internal_size, precision, scale, null_ok

--- a/src/rockset_sqlalchemy/client/exceptions.py
+++ b/src/rockset_sqlalchemy/client/exceptions.py
@@ -28,7 +28,7 @@ class Error(rockset.exceptions.RocksetException):
             exc_type == rockset.exceptions.ForbiddenException
         ):
             ret = OperationalError(*args)
-        elif exc_type == ServiceException:
+        elif exc_type == rockset.exceptions.ServiceException:
             ret = InternalError(*args)
         else:
             ret = cls(*args)

--- a/src/rockset_sqlalchemy/client/sqlalchemy/__init__.py
+++ b/src/rockset_sqlalchemy/client/sqlalchemy/__init__.py
@@ -1,3 +1,3 @@
 from .dialect import RocksetDialect
 
-__all__ = [RocksetDialect]
+__all__ = ["RocksetDialect"]

--- a/src/rockset_sqlalchemy/client/sqlalchemy/dialect.py
+++ b/src/rockset_sqlalchemy/client/sqlalchemy/dialect.py
@@ -48,6 +48,13 @@ class RocksetDialect(default.DefaultDialect):
 
         return client
 
+    def create_connect_args(self, url):
+        kwargs = {
+            "api_server": "https://{}".format(url.host),
+            "api_key": url.password or url.username
+        }
+        return ([], kwargs)
+
     @reflection.cache
     def get_schema_names(self, connection, **kw):
         return [w["name"] for w in connection.connect().connection._client.Workspaces.list()["data"]]

--- a/src/rockset_sqlalchemy/client/sqlalchemy/dialect.py
+++ b/src/rockset_sqlalchemy/client/sqlalchemy/dialect.py
@@ -66,7 +66,7 @@ class RocksetDialect(default.DefaultDialect):
 
         # Get a single row and determine the schema from that.
         # This assumes the whole collection has a fixed schema of course.
-        q = f"DESCRIBE {schema}.{table_name}"
+        q = f"SELECT * FROM {schema}.{table_name} LIMIT 1"
         try:
             cursor = connection.connect().connection.cursor()
             cursor.execute(q)

--- a/src/rockset_sqlalchemy/client/sqlalchemy/dialect.py
+++ b/src/rockset_sqlalchemy/client/sqlalchemy/dialect.py
@@ -50,16 +50,15 @@ class RocksetDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_schema_names(self, connection, **kw):
-        return [w["name"] for w in connection.connect()._client.Workspace.list()]
+        return [w["name"] for w in connection.connect().connection._client.Workspaces.list()["data"]]
 
     @reflection.cache
     def get_table_names(self, connection, schema=None, **kw):
-        if schema is None:
-            schema = RocksetDialect.default_schema_name
-        return [
-            w["name"]
-            for w in connection.connect()._client.Collection.list(workspace=schema)
-        ]
+        tables = (connection.connect().connection._client.Collections.list()
+                if schema is None else 
+                connection.connect().connection._client.Collections.workspace_collections(workspace=schema))['data']
+            
+        return [w["name"] for w in tables]
 
     def _get_table_columns(self, connection, table_name, schema):
         schema = self.identifier_preparer.quote_identifier(schema)
@@ -67,7 +66,7 @@ class RocksetDialect(default.DefaultDialect):
 
         # Get a single row and determine the schema from that.
         # This assumes the whole collection has a fixed schema of course.
-        q = "SELECT * FROM {}.{} LIMIT 1".format(schema, table_name)
+        q = f"DESCRIBE {schema}.{table_name}"
         try:
             cursor = connection.connect().connection.cursor()
             cursor.execute(q)
@@ -75,34 +74,33 @@ class RocksetDialect(default.DefaultDialect):
             if not fields:
                 # Return a fake schema if the collection is empty.
                 return [("null", "null")]
-            field_type = fields[1]
-            if field_type not in type_map:
-                raise exc.SQLAlchemyError(
-                    "Query returned unsupported type {} in field {} in table {}.{}".format(
-                        field_type, fields[0], schema, table_name
+            columns = []
+            for field in fields:
+                field_type = field[1]
+                if field_type not in type_map.keys():
+                    raise exc.SQLAlchemyError(
+                        "Query returned unsupported type {} in field {} in table {}.{}".format(
+                            field_type, fields[0], schema, table_name
+                        )
                     )
+                columns.append(
+                    {
+                        "name": field[0],
+                        "type": type_map[field_type],
+                        "nullable": field[6],
+                        "default": None,
+                    }
                 )
-            return [
-                {
-                    "name": field[0],
-                    "type": field[1],
-                    "nullable": field[6],
-                    "default": None,
-                }
-                for field in fields
-            ]
         except Exception as e:
             # TODO: more graceful handling of exceptions.
             raise e
+        return columns
 
     @reflection.cache
     def get_columns(self, connection, table_name, schema=None, **kw):
         if schema is None:
             schema = RocksetDialect.default_schema_name
-        columns = []
-        for column in self._get_table_columns(connection, table_name, schema):
-            columns.append(column)
-        return columns
+        return self._get_table_columns(connection, table_name, schema)
 
     @reflection.cache
     def get_view_names(self, connection, schema=None, **kw):
@@ -121,6 +119,13 @@ class RocksetDialect(default.DefaultDialect):
     @reflection.cache
     def get_indexes(self, connection, table_name, schema=None, **kw):
         return []
+    
+    def has_table(self, connection, table_name, schema=None):
+        try:
+            self._get_table_columns(connection, table_name, schema)
+            return True
+        except exc.NoSuchTableError:
+            return False
 
     def do_rollback(self, dbapi_connection):
         # Transactions are not supported in Rockset.

--- a/src/rockset_sqlalchemy/client/sqlalchemy/types.py
+++ b/src/rockset_sqlalchemy/client/sqlalchemy/types.py
@@ -54,7 +54,7 @@ class Time(BaseType, types.TIME):
     __visit_name__ = rockset.document.DATATYPE_TIME
 
 
-class Time(BaseType, types.String):
+class Timestamp(BaseType, types.String):
     __visit_name__ = rockset.document.DATATYPE_TIMESTAMP
 
 
@@ -83,18 +83,19 @@ class Geography(Object):
 
 
 type_map = {
-    rockset.document.DATATYPE_NULL: NullType,
-    rockset.document.DATATYPE_INT: Int,
-    rockset.document.DATATYPE_FLOAT: Float,
-    rockset.document.DATATYPE_BOOL: Bool,
-    rockset.document.DATATYPE_STRING: String,
-    rockset.document.DATATYPE_BYTES: Bytes,
-    rockset.document.DATATYPE_OBJECT: Object,
-    rockset.document.DATATYPE_ARRAY: Array,
-    rockset.document.DATATYPE_DATE: Date,
-    rockset.document.DATATYPE_DATETIME: DateTime,
-    rockset.document.DATATYPE_TIME: Time,
-    rockset.document.DATATYPE_MICROSECOND_INTERVAL: MicrosecondInterval,
-    rockset.document.DATATYPE_MONTH_INTERVAL: MonthInterval,
-    rockset.document.DATATYPE_GEOGRAPHY: Geography,
+    "null": NullType,
+    "int": Int,
+    "float": Float,
+    "bool": Bool,
+    "string": String,
+    "bytes": Bytes,
+    "object": Object,
+    "array": Array,
+    "date": Date,
+    "datetime": DateTime,
+    "time": Time,
+    "timestamp": Timestamp,
+    "microsecond_interval": MicrosecondInterval,
+    "month_interval": MonthInterval,
+    "geography": Geography,
 }


### PR DESCRIPTION
This PR fixes support for Rockset's v2 client. 

1. Adds the `rockset://` URI in addition to `rockset_sqlalchemy://`. Most SQLAlchemy URIs don't include "sqlalchemy" in their URI (e.g. `snowflake://`).
2. Changed types of `__all__` declarations to `List[str]` [to avoid `AttributeError`](https://stackoverflow.com/questions/41860105/why-should-all-only-contain-string-objects).
3. Fix `types.type_map` to apply to types of new Python client.