### PR TITLE
Add compatibility with SQLAlchemy 2.x

### DIFF
--- a/example.py
+++ b/example.py
@@ -4,8 +4,7 @@ from collections import defaultdict
 
 import sqlalchemy as sa
 from sqlalchemy import cast, create_engine, or_
-from sqlalchemy.ext import declarative
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 from rockset_sqlalchemy.sqlalchemy.types import Array
 
@@ -25,8 +24,7 @@ engine = create_engine(
     },
 )
 
-Base = declarative.declarative_base(bind=engine)
-
+class Base(DeclarativeBase): pass
 
 class Person(Base):
     __tablename__ = "people"

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     },
     install_requires=[
         "rockset>=1.0.0",
-        "sqlalchemy>=1.4.0,<2.0.0"
+        "sqlalchemy>=1.4.0"
     ],
     classifiers=[
         'Programming Language :: Python :: 3',

--- a/src/rockset_sqlalchemy/sqlalchemy/dialect.py
+++ b/src/rockset_sqlalchemy/sqlalchemy/dialect.py
@@ -34,6 +34,7 @@ class RocksetDialect(default.DefaultDialect):
     supports_sane_rowcount = False
     supports_sane_multi_rowcount = False
     preexecute_autoincrement_sequences = False
+    supports_statement_cache = True
 
     supports_default_values = False
     supports_sequences = False
@@ -42,9 +43,15 @@ class RocksetDialect(default.DefaultDialect):
 
     @classmethod
     def dbapi(cls):
+        """Retained for backward compatibility with SQLAlchemy 1.x.
+        """
         import rockset_sqlalchemy
 
         return rockset_sqlalchemy
+    
+    @classmethod
+    def import_dbapi(cls):
+        return RocksetDialect.dbapi()
 
     def create_connect_args(self, url):
         kwargs = {


### PR DESCRIPTION
`rockset-sqlalchemy` should now be compatible with newer versions of `sqlalchemy`. This change is backward compatible.
Ran `example.py` successfully. 

***

SQLAlchemy's 1.4->2.0 [migration guide](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html). 