### PR TITLE
Force _event_time to be a datetime type

### DIFF
--- a/src/rockset_sqlalchemy/sqlalchemy/dialect.py
+++ b/src/rockset_sqlalchemy/sqlalchemy/dialect.py
@@ -102,6 +102,8 @@ class RocksetDialect(default.DefaultDialect):
                             field_type, fields[0], schema, table_name
                         )
                     )
+                if field[0] == "_event_time":
+                    field_type = "timestamp"
                 columns.append(
                     {
                         "name": field[0],


### PR DESCRIPTION
## Summary
It makes things so much easier in applications like superset because the
column is properly used.

## Test plan

Changed the type, created a new wheel and used it in superset

Reviewers: haneeshr
